### PR TITLE
#4: add tag_format option to provider

### DIFF
--- a/pkg/provider/gitlab.go
+++ b/pkg/provider/gitlab.go
@@ -13,7 +13,7 @@ import (
 	"github.com/xanzy/go-gitlab"
 )
 
-const TAG_VERSION = "{version}"
+const TAG_PLACEHOLDER = "{version}"
 
 var PVERSION = "dev"
 
@@ -53,7 +53,7 @@ func (repo *GitLabRepository) Init(config map[string]string) error {
 
 	tagFormat := config["tag_format"]
 	if tagFormat == "" {
-		tagFormat = "v" + TAG_VERSION
+		tagFormat = "v" + TAG_PLACEHOLDER
 	}
 
 	repo.projectID = projectID
@@ -176,7 +176,7 @@ func (repo *GitLabRepository) GetReleases(rawRe string) ([]*semrel.Release, erro
 }
 
 func (repo *GitLabRepository) CreateRelease(release *provider.CreateReleaseConfig) error {
-	tag := strings.ReplaceAll(repo.tagFormat, TAG_VERSION, release.NewVersion)
+	tag := strings.ReplaceAll(repo.tagFormat, TAG_PLACEHOLDER, release.NewVersion)
 
 	// Gitlab does not have any notion of pre-releases
 	_, _, err := repo.client.Releases.CreateRelease(repo.projectID, &gitlab.CreateReleaseOptions{

--- a/pkg/provider/gitlab.go
+++ b/pkg/provider/gitlab.go
@@ -52,7 +52,8 @@ func (repo *GitLabRepository) Init(config map[string]string) error {
 	var err error
 	stripVTagPrefix := config["strip_v_tag_prefix"]
 	repo.stripVTagPrefix, err = strconv.ParseBool(stripVTagPrefix)
-	if err != nil {
+
+	if stripVTagPrefix != "" && err != nil {
 		return fmt.Errorf("failed to set property strip_v_tag_prefix: %w", err)
 	}
 

--- a/pkg/provider/gitlab.go
+++ b/pkg/provider/gitlab.go
@@ -171,9 +171,9 @@ func (repo *GitLabRepository) GetReleases(rawRe string) ([]*semrel.Release, erro
 }
 
 func (repo *GitLabRepository) CreateRelease(release *provider.CreateReleaseConfig) error {
-	var prefix string
+	prefix := "v"
 	if repo.stripVTagPrefix {
-		prefix = "v"
+		prefix = ""
 	}
 
 	tag := prefix + release.NewVersion

--- a/pkg/provider/gitlab_test.go
+++ b/pkg/provider/gitlab_test.go
@@ -36,10 +36,10 @@ func TestNewGitlabRepository(t *testing.T) {
 
 	repo = &GitLabRepository{}
 	err = repo.Init(map[string]string{
-		"gitlab_baseurl":   "https://mygitlab.com",
-		"token":            "token",
-		"gitlab_projectid": "1",
-		"tag_format":       "{version}",
+		"gitlab_baseurl":     "https://mygitlab.com",
+		"token":              "token",
+		"gitlab_projectid":   "1",
+		"strip_v_tag_prefix": "true",
 	})
 	require.NoError(err)
 	require.Equal("https://mygitlab.com/api/v4/", repo.client.BaseURL().String(), "invalid custom instance initialization")
@@ -193,17 +193,17 @@ func TestGitlabCreateRelease(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestGitlabTagFormatRelease(t *testing.T) {
+func TestGitlabStripVTagRelease(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(GitlabHandler))
 	defer ts.Close()
 
 	repo := &GitLabRepository{}
 	err := repo.Init(map[string]string{
-		"gitlab_baseurl":   ts.URL,
-		"token":            "gitlab-examples-ci",
-		"gitlab_branch":    "",
-		"gitlab_projectid": strconv.Itoa(GITLAB_PROJECT_ID),
-		"tag_format":       "{version}",
+		"gitlab_baseurl":     ts.URL,
+		"token":              "gitlab-examples-ci",
+		"gitlab_branch":      "",
+		"gitlab_projectid":   strconv.Itoa(GITLAB_PROJECT_ID),
+		"strip_v_tag_prefix": "true",
 	})
 
 	require.NoError(t, err)


### PR DESCRIPTION
Added the `tag_format` option to allow pushing different tag formats.

https://semantic-release.gitbook.io/semantic-release/usage/configuration#tagformat

Usage example:

```json

    "provider": {
      "name": "gitlab",
      "options": {
        "tag_format": "{version}"
      }
    },

```