### PR TITLE
feat: Align algorith to aquire tokens with goreleaser

### DIFF
--- a/pkg/provider/gitlab.go
+++ b/pkg/provider/gitlab.go
@@ -63,7 +63,6 @@ func (repo *GitLabRepository) Init(config map[string]string) error {
 		}
 	}
 
-
 	branch := config["gitlab_branch"]
 	if branch == "" {
 		branch = os.Getenv("CI_COMMIT_BRANCH")

--- a/pkg/provider/gitlab.go
+++ b/pkg/provider/gitlab.go
@@ -38,30 +38,31 @@ func (repo *GitLabRepository) Init(config map[string]string) error {
 	token := config["token"]
 	if token == "" {
 		token = os.Getenv("GITLAB_TOKEN")
-		ci_job_token := os.Getenv("CI_JOB_TOKEN")
-		if token == "" {
-			if ci_job_token == "" {
-				return errors.New("gitlab token missing")
-			}
-			token = ci_job_token
+	}
+	ciJobToken := os.Getenv("CI_JOB_TOKEN")
+	if token == "" {
+		if ciJobToken == "" {
+			return errors.New("gitlab token missing")
 		}
-		// use the same strategy as goreleaser
-		if token == ci_job_token {
-			repo.useJobToken = true
-			if os.Getenv("GIT_STRATEGY") == "none" {
-				return errors.New("can not use job token with sparse-checkout repository")
-			}
-			repo.localRepo = &GitProvider.Repository{}
-			err := repo.localRepo.Init(map[string]string{
-				"remote_name": "origin",
-				"git_path":    os.Getenv("CI_PROJECT_DIR"),
-				"log_order":   config["log_order"],
-			})
-			if err != nil {
-				return errors.New("failed to initialize local git repository: " + err.Error())
-			}
+		token = ciJobToken
+	}
+	// use the same strategy as goreleaser
+	if token == ciJobToken {
+		repo.useJobToken = true
+		if os.Getenv("GIT_STRATEGY") == "none" {
+			return errors.New("can not use job token with sparse-checkout repository")
+		}
+		repo.localRepo = &GitProvider.Repository{}
+		err := repo.localRepo.Init(map[string]string{
+			"remote_name": "origin",
+			"git_path":    os.Getenv("CI_PROJECT_DIR"),
+			"log_order":   config["log_order"],
+		})
+		if err != nil {
+			return errors.New("failed to initialize local git repository: " + err.Error())
 		}
 	}
+
 
 	branch := config["gitlab_branch"]
 	if branch == "" {


### PR DESCRIPTION
This PR solves an inconsistency between `provider-gitlab` and `hook-goreleaser` when running in ci.

`hook-goreleaser` (and plain `goreleaser`) gets `GITLAB_TOKEN`, which is then checked against `CI_JOB_TOKEN` variable later in code. It then uses different API constructor calls to upload the release. It fails to find `GITLAB_TOKEN`, it will fail the release process.

`provider-gitlab` uses blindly `GITLAB_TOKEN` and assumes it is a valid api token. If it is missing, it uses `CI_JOB_TOKEN` with git repo. This fails in a situation where `GITLAB_TOKEN == CI_JOB_TOKEN`, since `CI_JOB_TOKEN` does NOT have access to the needed APIs.

This situation creates an impasse to run `semantic-release` with `hook-goreleaser` in Gitlab-CI with just a job token. This PR fixes this problem by aligning token fetching algorithms.